### PR TITLE
Fixed Translation (de) for "txtEncoding"

### DIFF
--- a/apps/documenteditor/main/locale/de.json
+++ b/apps/documenteditor/main/locale/de.json
@@ -166,7 +166,7 @@
   "Common.Views.LanguageDialog.labelSelect": "Sprache des Dokuments wählen",
   "Common.Views.OpenDialog.cancelButtonText": "Abbrechen",
   "Common.Views.OpenDialog.okButtonText": "OK",
-  "Common.Views.OpenDialog.txtEncoding": "Verschlüsselung ",
+  "Common.Views.OpenDialog.txtEncoding": "Zeichenkodierung",
   "Common.Views.OpenDialog.txtPassword": "Kennwort",
   "Common.Views.OpenDialog.txtTitle": "%1-Optionen wählen",
   "Common.Views.OpenDialog.txtTitleProtected": "Geschützte Datei",

--- a/apps/presentationeditor/main/locale/de.json
+++ b/apps/presentationeditor/main/locale/de.json
@@ -99,7 +99,7 @@
   "Common.Views.LanguageDialog.labelSelect": "Sprache des Dokuments wählen",
   "Common.Views.OpenDialog.cancelButtonText": "Abbrechen",
   "Common.Views.OpenDialog.okButtonText": "OK",
-  "Common.Views.OpenDialog.txtEncoding": "Verschlüsselung",
+  "Common.Views.OpenDialog.txtEncoding": "Zeichenkodierung",
   "Common.Views.OpenDialog.txtPassword": "Kennwort",
   "Common.Views.OpenDialog.txtTitle": "%1-Optionen wählen",
   "Common.Views.OpenDialog.txtTitleProtected": "Geschützte Datei",

--- a/apps/spreadsheeteditor/main/locale/de.json
+++ b/apps/spreadsheeteditor/main/locale/de.json
@@ -83,7 +83,7 @@
   "Common.Views.OpenDialog.cancelButtonText": "Abbrechen",
   "Common.Views.OpenDialog.okButtonText": "OK",
   "Common.Views.OpenDialog.txtDelimiter": "Trennzeichen",
-  "Common.Views.OpenDialog.txtEncoding": "Verschlüsselung",
+  "Common.Views.OpenDialog.txtEncoding": "Zeichenkodierung",
   "Common.Views.OpenDialog.txtOther": "Sonstige",
   "Common.Views.OpenDialog.txtPassword": "Kennwort",
   "Common.Views.OpenDialog.txtSpace": "Leerzeichen",

--- a/apps/spreadsheeteditor/mobile/locale/de.json
+++ b/apps/spreadsheeteditor/mobile/locale/de.json
@@ -218,7 +218,7 @@
   "SSE.Controllers.Main.txtDelimiter": "Trennzeichen",
   "SSE.Controllers.Main.txtDiagramTitle": "Diagrammtitel",
   "SSE.Controllers.Main.txtEditingMode": "Bearbeitungsmodus einschalten...",
-  "SSE.Controllers.Main.txtEncoding": "Verschlüsselung ",
+  "SSE.Controllers.Main.txtEncoding": "Zeichenkodierung",
   "SSE.Controllers.Main.txtErrorLoadHistory": "Laden der Historie ist fehlgeschlagen",
   "SSE.Controllers.Main.txtFiguredArrows": "Geformte Pfeile",
   "SSE.Controllers.Main.txtLines": "Linien",


### PR DESCRIPTION
Encoding should be translated to "Zeichenkodierung" not "Verschlüsselung"